### PR TITLE
test: 애플 아이디로 로그인/회원가입 상태코드 401 인수테스트 추가

### DIFF
--- a/src/main/java/dandi/dandi/advice/ExceptionResponse.java
+++ b/src/main/java/dandi/dandi/advice/ExceptionResponse.java
@@ -5,7 +5,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public class ExceptionResponse {
 
     @Schema(example = "Exception Message")
-    private final String message;
+    private String message;
+
+    public ExceptionResponse() {
+    }
 
     public ExceptionResponse(String message) {
         this.message = message;

--- a/src/test/java/dandi/dandi/auth/acceptance/AuthAcceptanceTest.java
+++ b/src/test/java/dandi/dandi/auth/acceptance/AuthAcceptanceTest.java
@@ -74,4 +74,24 @@ class AuthAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(exceptionMessage).isEqualTo(unauthorizedException.getMessage())
         );
     }
+
+    @DisplayName("유효하지 않은 iss, client-id, nonce의 Apple Identity Token으로 로그인/회원가입을 요청하면 401을 반환한다.")
+    @Test
+    void login_Unauthorized_InvalidAppleIdToken() {
+        String invalidToken = "invalidToken";
+        UnauthorizedException unauthorizedException = UnauthorizedException.invalid();
+        when(oAuthClient.getOAuthMemberId(invalidToken))
+                .thenThrow(unauthorizedException);
+
+        ExtractableResponse<Response> response = HttpMethodFixture.httpPost(new LoginRequest(invalidToken),
+                LOGIN_REQUEST_URI);
+
+        String exceptionMessage = response.jsonPath()
+                .getObject(".", ExceptionResponse.class)
+                .getMessage();
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value()),
+                () -> assertThat(exceptionMessage).isEqualTo(unauthorizedException.getMessage())
+        );
+    }
 }


### PR DESCRIPTION
애플 아이디로 로그인/회원가입 상태코드 401 인수테스트 추가
resolve #19