### PR TITLE
build: build 시에 -plain.jar 파일 생성되지 않도록 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,10 @@ group = 'dandi'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 
+jar {
+	enabled = false
+}
+
 repositories {
 	mavenCentral()
 }


### PR DESCRIPTION
resolve #137 