### PR TITLE
fix: 게시글 상세정보 반환시, CloudFront 주소가 중복으로 응답 값에 담기는 문제 해결

### DIFF
--- a/src/main/java/dandi/dandi/post/application/service/PostService.java
+++ b/src/main/java/dandi/dandi/post/application/service/PostService.java
@@ -18,11 +18,14 @@ public class PostService implements PostUseCase {
 
     private final PostPersistencePort postPersistencePort;
     private final String imageAccessUrl;
+    private final String postImageDir;
 
     public PostService(PostPersistencePort postPersistencePort,
-                       @Value("${cloud.aws.cloud-front.uri}") String imageAccessUrl) {
+                       @Value("${cloud.aws.cloud-front.uri}") String imageAccessUrl,
+                       @Value("${image.post-dir}") String postImageDir) {
         this.postPersistencePort = postPersistencePort;
         this.imageAccessUrl = imageAccessUrl;
+        this.postImageDir = postImageDir;
     }
 
     @Override
@@ -32,9 +35,14 @@ public class PostService implements PostUseCase {
                 postRegisterCommand.getMinTemperature(), postRegisterCommand.getMaxTemperature());
         WeatherFeeling weatherFeeling = new WeatherFeeling(
                 postRegisterCommand.getFeelingIndex(), postRegisterCommand.getAdditionalFeelingIndices());
-        Post post = Post.initial(temperatures, postRegisterCommand.getPostImageUrl(), weatherFeeling);
+        String postImageUrl = removeImageAccessUrl(postRegisterCommand.getPostImageUrl());
+        Post post = Post.initial(temperatures, postImageUrl, weatherFeeling);
         Long postId = postPersistencePort.save(post, memberId);
         return new PostRegisterResponse(postId);
+    }
+
+    private String removeImageAccessUrl(String postImageUrl) {
+        return postImageUrl.substring(postImageUrl.indexOf(postImageDir));
     }
 
     @Override

--- a/src/test/java/dandi/dandi/post/PostFixture.java
+++ b/src/test/java/dandi/dandi/post/PostFixture.java
@@ -10,11 +10,12 @@ import java.util.List;
 
 public class PostFixture {
 
+    public static final String POST_IMAGE_DIR = "post";
     public static final Long POST_ID = 1L;
     public static final double MIN_TEMPERATURE = 20.0;
     public static final double MAX_TEMPERATURE = 30.0;
     public static final Temperatures TEMPERATURES = new Temperatures(MIN_TEMPERATURE, MAX_TEMPERATURE);
-    public static final String POST_IMAGE_URL = "postImageUrl";
+    public static final String POST_IMAGE_URL = POST_IMAGE_DIR + "/postImageUrl";
     public static final Long OUTFIT_FEELING_INDEX = 1L;
     public static final List<Long> ADDITIONAL_OUTFIT_FEELING_INDICES = List.of(1L, 2L);
     public static final WeatherFeeling WEATHER_FEELING =

--- a/src/test/java/dandi/dandi/post/application/service/PostImageServiceTest.java
+++ b/src/test/java/dandi/dandi/post/application/service/PostImageServiceTest.java
@@ -1,5 +1,6 @@
 package dandi.dandi.post.application.service;
 
+import static dandi.dandi.post.PostFixture.POST_IMAGE_DIR;
 import static dandi.dandi.utils.image.TestImageUtils.IMAGE_ACCESS_URL;
 import static dandi.dandi.utils.image.TestImageUtils.generateTestImgMultipartFile;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -25,10 +26,9 @@ import org.springframework.web.multipart.MultipartFile;
 @ExtendWith(MockitoExtension.class)
 class PostImageServiceTest {
 
-    private final String postImageDir = "post-image";
     private final ImageUploader imageUploader = Mockito.mock(ImageUploader.class);
     private final PostImageService postImageService =
-            new PostImageService(imageUploader, postImageDir, IMAGE_ACCESS_URL);
+            new PostImageService(imageUploader, POST_IMAGE_DIR, IMAGE_ACCESS_URL);
 
     @DisplayName("게시글 사진을 업로드할 수 있다.")
     @Test
@@ -41,7 +41,7 @@ class PostImageServiceTest {
         assertAll(
                 () -> verify(imageUploader).upload(anyString(), any(InputStream.class)),
                 () -> assertThat(postImageRegisterResponse.getPostImageUrl())
-                        .startsWith(IMAGE_ACCESS_URL + postImageDir)
+                        .startsWith(IMAGE_ACCESS_URL + POST_IMAGE_DIR)
                         .contains(multipartFile.getOriginalFilename())
                         .contains(String.valueOf(memberId))
         );

--- a/src/test/java/dandi/dandi/post/application/service/PostServiceTest.java
+++ b/src/test/java/dandi/dandi/post/application/service/PostServiceTest.java
@@ -4,6 +4,7 @@ import static dandi.dandi.post.PostFixture.ADDITIONAL_OUTFIT_FEELING_INDICES;
 import static dandi.dandi.post.PostFixture.MAX_TEMPERATURE;
 import static dandi.dandi.post.PostFixture.MIN_TEMPERATURE;
 import static dandi.dandi.post.PostFixture.OUTFIT_FEELING_INDEX;
+import static dandi.dandi.post.PostFixture.POST_IMAGE_DIR;
 import static dandi.dandi.post.PostFixture.POST_IMAGE_URL;
 import static dandi.dandi.post.PostFixture.TEST_POST;
 import static dandi.dandi.utils.image.TestImageUtils.IMAGE_ACCESS_URL;
@@ -29,7 +30,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class PostServiceTest {
 
     private final PostPersistencePort postPersistencePort = Mockito.mock(PostPersistencePort.class);
-    private final PostService postService = new PostService(postPersistencePort, IMAGE_ACCESS_URL);
+    private final PostService postService = new PostService(postPersistencePort, IMAGE_ACCESS_URL, POST_IMAGE_DIR);
 
     @DisplayName("게시글을 작성할 수 있다.")
     @Test


### PR DESCRIPTION
resolve #169 