### PR TITLE
refactor: member package의 web, application을 command와 query 분리

### DIFF
--- a/src/main/java/dandi/dandi/comment/adapter/persistence/CommentPersistenceAdapter.java
+++ b/src/main/java/dandi/dandi/comment/adapter/persistence/CommentPersistenceAdapter.java
@@ -3,7 +3,7 @@ package dandi.dandi.comment.adapter.persistence;
 import dandi.dandi.advice.InternalServerException;
 import dandi.dandi.comment.application.port.out.CommentPersistencePort;
 import dandi.dandi.comment.domain.Comment;
-import dandi.dandi.member.adapter.out.persistence.MemberRepository;
+import dandi.dandi.member.adapter.out.persistence.jpa.MemberRepository;
 import dandi.dandi.member.domain.Member;
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/dandi/dandi/comment/adapter/persistence/CommentRepository.java
+++ b/src/main/java/dandi/dandi/comment/adapter/persistence/CommentRepository.java
@@ -9,9 +9,9 @@ public interface CommentRepository extends JpaRepository<CommentJpaEntity, Long>
 
     @Query("SELECT c FROM CommentJpaEntity c WHERE c.postId = :postId "
             + "AND c.memberId NOT IN "
-            + "(SELECT mb.blockedMemberId FROM MemberBlockJpaEntity mb WHERE mb.blockingMemberId = :memberId ) "
+            + "(SELECT mb.blockedMemberId FROM MemberBlockEntity mb WHERE mb.blockingMemberId = :memberId ) "
             + "AND c.memberId NOT IN "
-            + "(SELECT mb.blockingMemberId FROM MemberBlockJpaEntity mb WHERE mb.blockedMemberId = :memberId )"
+            + "(SELECT mb.blockingMemberId FROM MemberBlockEntity mb WHERE mb.blockedMemberId = :memberId )"
             + "AND c.id NOT IN "
             + "(SELECT cr.commentId FROM CommentReportJpaEntity cr WHERE cr.memberId = :memberId)")
     Slice<CommentJpaEntity> findByPostId(Long memberId, Long postId, Pageable pageable);

--- a/src/main/java/dandi/dandi/member/adapter/out/persistence/jpa/LocationEntity.java
+++ b/src/main/java/dandi/dandi/member/adapter/out/persistence/jpa/LocationEntity.java
@@ -1,11 +1,11 @@
-package dandi.dandi.member.adapter.out.persistence;
+package dandi.dandi.member.adapter.out.persistence.jpa;
 
 import dandi.dandi.member.domain.District;
 import dandi.dandi.member.domain.Location;
 import javax.persistence.Embeddable;
 
 @Embeddable
-public class LocationJpaEntity {
+public class LocationEntity {
 
     private double latitude;
     private double longitude;
@@ -13,10 +13,10 @@ public class LocationJpaEntity {
     private String city;
     private String town;
 
-    private LocationJpaEntity() {
+    private LocationEntity() {
     }
 
-    public LocationJpaEntity(double latitude, double longitude, District district) {
+    public LocationEntity(double latitude, double longitude, District district) {
         this.latitude = latitude;
         this.longitude = longitude;
         this.country = district.getCountry();

--- a/src/main/java/dandi/dandi/member/adapter/out/persistence/jpa/MemberBlockEntity.java
+++ b/src/main/java/dandi/dandi/member/adapter/out/persistence/jpa/MemberBlockEntity.java
@@ -1,4 +1,4 @@
-package dandi.dandi.member.adapter.out.persistence;
+package dandi.dandi.member.adapter.out.persistence.jpa;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -9,7 +9,7 @@ import javax.persistence.Table;
 
 @Entity
 @Table(name = "member_block")
-public class MemberBlockJpaEntity {
+public class MemberBlockEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -19,10 +19,10 @@ public class MemberBlockJpaEntity {
     private Long blockingMemberId;
     private Long blockedMemberId;
 
-    protected MemberBlockJpaEntity() {
+    protected MemberBlockEntity() {
     }
 
-    public MemberBlockJpaEntity(Long blockingMemberId, Long blockedMemberId) {
+    public MemberBlockEntity(Long blockingMemberId, Long blockedMemberId) {
         this.blockingMemberId = blockingMemberId;
         this.blockedMemberId = blockedMemberId;
     }

--- a/src/main/java/dandi/dandi/member/adapter/out/persistence/jpa/MemberBlockPersistenceAdapter.java
+++ b/src/main/java/dandi/dandi/member/adapter/out/persistence/jpa/MemberBlockPersistenceAdapter.java
@@ -1,4 +1,4 @@
-package dandi.dandi.member.adapter.out.persistence;
+package dandi.dandi.member.adapter.out.persistence.jpa;
 
 import dandi.dandi.member.application.port.out.MemberBlockPersistencePort;
 import org.springframework.stereotype.Component;
@@ -14,8 +14,8 @@ public class MemberBlockPersistenceAdapter implements MemberBlockPersistencePort
 
     @Override
     public void saveMemberBlockOf(Long blockingMemberId, Long blockedMemberId) {
-        MemberBlockJpaEntity memberBlockJpaEntity = new MemberBlockJpaEntity(blockingMemberId, blockedMemberId);
-        memberBlockRepository.save(memberBlockJpaEntity);
+        MemberBlockEntity memberBlockEntity = new MemberBlockEntity(blockingMemberId, blockedMemberId);
+        memberBlockRepository.save(memberBlockEntity);
     }
 
     @Override

--- a/src/main/java/dandi/dandi/member/adapter/out/persistence/jpa/MemberBlockRepository.java
+++ b/src/main/java/dandi/dandi/member/adapter/out/persistence/jpa/MemberBlockRepository.java
@@ -1,8 +1,8 @@
-package dandi.dandi.member.adapter.out.persistence;
+package dandi.dandi.member.adapter.out.persistence.jpa;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MemberBlockRepository extends JpaRepository<MemberBlockJpaEntity, Long> {
+public interface MemberBlockRepository extends JpaRepository<MemberBlockEntity, Long> {
 
     boolean existsByBlockingMemberIdAndBlockedMemberId(Long blockingMemberId, Long blockedMemberId);
 }

--- a/src/main/java/dandi/dandi/member/adapter/out/persistence/jpa/MemberEntity.java
+++ b/src/main/java/dandi/dandi/member/adapter/out/persistence/jpa/MemberEntity.java
@@ -1,4 +1,4 @@
-package dandi.dandi.member.adapter.out.persistence;
+package dandi.dandi.member.adapter.out.persistence.jpa;
 
 import dandi.dandi.member.domain.Member;
 import javax.persistence.Column;
@@ -11,7 +11,7 @@ import javax.persistence.Table;
 
 @Entity
 @Table(name = "member")
-public class MemberJpaEntity {
+public class MemberEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,28 +24,28 @@ public class MemberJpaEntity {
     private String nickname;
 
     @Embedded
-    private LocationJpaEntity locationJpaEntity;
+    private LocationEntity locationEntity;
 
     private String profileImgUrl;
 
-    protected MemberJpaEntity() {
+    protected MemberEntity() {
     }
 
-    private MemberJpaEntity(Long id, String oAuthId, String nickname, LocationJpaEntity locationJpaEntity,
-                            String profileImgUrl) {
+    private MemberEntity(Long id, String oAuthId, String nickname, LocationEntity locationEntity,
+                         String profileImgUrl) {
         this.id = id;
         this.oAuthId = oAuthId;
         this.nickname = nickname;
-        this.locationJpaEntity = locationJpaEntity;
+        this.locationEntity = locationEntity;
         this.profileImgUrl = profileImgUrl;
     }
 
-    public static MemberJpaEntity fromMember(Member member) {
-        return new MemberJpaEntity(
+    public static MemberEntity fromMember(Member member) {
+        return new MemberEntity(
                 member.getId(),
                 member.getOAuthId(),
                 member.getNickname(),
-                new LocationJpaEntity(member.getLatitude(), member.getLongitude(), member.getDistrict()),
+                new LocationEntity(member.getLatitude(), member.getLongitude(), member.getDistrict()),
                 member.getProfileImgUrl()
         );
     }
@@ -59,7 +59,7 @@ public class MemberJpaEntity {
                 id,
                 oAuthId,
                 nickname,
-                locationJpaEntity.toLocation(),
+                locationEntity.toLocation(),
                 profileImgUrl
         );
     }

--- a/src/main/java/dandi/dandi/member/adapter/out/persistence/jpa/MemberPersistenceAdapter.java
+++ b/src/main/java/dandi/dandi/member/adapter/out/persistence/jpa/MemberPersistenceAdapter.java
@@ -1,4 +1,4 @@
-package dandi.dandi.member.adapter.out.persistence;
+package dandi.dandi.member.adapter.out.persistence.jpa;
 
 import dandi.dandi.member.application.port.out.MemberPersistencePort;
 import dandi.dandi.member.domain.District;
@@ -23,20 +23,20 @@ public class MemberPersistenceAdapter implements MemberPersistencePort {
 
     @Override
     public Member save(Member member) {
-        return memberRepository.save(MemberJpaEntity.fromMember(member))
+        return memberRepository.save(MemberEntity.fromMember(member))
                 .toMember();
     }
 
     @Override
     public Optional<Member> findById(Long memberId) {
         return memberRepository.findById(memberId)
-                .map(MemberJpaEntity::toMember);
+                .map(MemberEntity::toMember);
     }
 
     @Override
     public Optional<Member> findByOAuthId(String oAuthId) {
         return memberRepository.findByOAuthId(oAuthId)
-                .map(MemberJpaEntity::toMember);
+                .map(MemberEntity::toMember);
     }
 
     @Override
@@ -73,9 +73,9 @@ public class MemberPersistenceAdapter implements MemberPersistencePort {
 
     @Override
     public Slice<Member> findPushNotificationAllowingMember(Pageable pageable) {
-        Slice<MemberJpaEntity> memberJpaEntities = memberRepository.findPushNotificationAllowingMember(pageable);
+        Slice<MemberEntity> memberJpaEntities = memberRepository.findPushNotificationAllowingMember(pageable);
         List<Member> pushNotificationAllowingMembers = memberJpaEntities.stream()
-                .map(MemberJpaEntity::toMember)
+                .map(MemberEntity::toMember)
                 .collect(Collectors.toUnmodifiableList());
         return new SliceImpl<>(pushNotificationAllowingMembers, pageable, memberJpaEntities.hasNext());
     }
@@ -83,7 +83,7 @@ public class MemberPersistenceAdapter implements MemberPersistencePort {
     @Override
     public Optional<Location> findLocationById(Long id) {
         return memberRepository.findLocationById(id)
-                .map(LocationJpaEntity::toLocation);
+                .map(LocationEntity::toLocation);
     }
 
     @Override

--- a/src/main/java/dandi/dandi/member/adapter/out/persistence/jpa/MemberPostPersistenceAdapter.java
+++ b/src/main/java/dandi/dandi/member/adapter/out/persistence/jpa/MemberPostPersistenceAdapter.java
@@ -1,4 +1,4 @@
-package dandi.dandi.member.adapter.out.persistence;
+package dandi.dandi.member.adapter.out.persistence.jpa;
 
 import dandi.dandi.post.adapter.out.PostRepository;
 import dandi.dandi.post.application.port.out.MemberPostPersistencePort;

--- a/src/main/java/dandi/dandi/member/adapter/out/persistence/jpa/MemberRepository.java
+++ b/src/main/java/dandi/dandi/member/adapter/out/persistence/jpa/MemberRepository.java
@@ -1,4 +1,4 @@
-package dandi.dandi.member.adapter.out.persistence;
+package dandi.dandi.member.adapter.out.persistence.jpa;
 
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
@@ -9,36 +9,36 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface MemberRepository extends JpaRepository<MemberJpaEntity, Long> {
+public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
 
-    @Query("SELECT m FROM MemberJpaEntity m WHERE m.oAuthId = :oAuthId")
-    Optional<MemberJpaEntity> findByOAuthId(String oAuthId);
+    @Query("SELECT m FROM MemberEntity m WHERE m.oAuthId = :oAuthId")
+    Optional<MemberEntity> findByOAuthId(String oAuthId);
 
     boolean existsMemberByNickname(String nickname);
 
     boolean existsByNicknameAndIdIsNot(String nickname, Long memberId);
 
     @Modifying
-    @Query("UPDATE MemberJpaEntity m SET m.profileImgUrl = :profileImageUrl WHERE m.id = :memberId")
+    @Query("UPDATE MemberEntity m SET m.profileImgUrl = :profileImageUrl WHERE m.id = :memberId")
     void updateProfileImageUrl(Long memberId, String profileImageUrl);
 
     @Modifying
-    @Query("UPDATE MemberJpaEntity m SET m.nickname = :nickname WHERE m.id = :memberId")
+    @Query("UPDATE MemberEntity m SET m.nickname = :nickname WHERE m.id = :memberId")
     void updateNickname(Long memberId, String nickname);
 
     @Modifying
-    @Query("UPDATE MemberJpaEntity m SET m.locationJpaEntity.longitude = :longitude,"
+    @Query("UPDATE MemberEntity m SET m.locationJpaEntity.longitude = :longitude,"
             + " m.locationJpaEntity.latitude = :latitude , m.locationJpaEntity.country = :country, "
             + "m.locationJpaEntity.city = :city, m.locationJpaEntity.town = :town WHERE m.id = :memberId")
     void updateLocation(Long memberId, Double latitude, Double longitude, String country, String city, String town);
 
-    @Query("SELECT m FROM MemberJpaEntity m INNER JOIN PushNotificationJpaEntity pn ON m.id = pn.memberId "
+    @Query("SELECT m FROM MemberEntity m INNER JOIN PushNotificationJpaEntity pn ON m.id = pn.memberId "
             + "WHERE pn.allowance = true")
-    Slice<MemberJpaEntity> findPushNotificationAllowingMember(Pageable pageable);
+    Slice<MemberEntity> findPushNotificationAllowingMember(Pageable pageable);
 
-    @Query("SELECT m.locationJpaEntity FROM MemberJpaEntity m WHERE m.id = :id")
-    Optional<LocationJpaEntity> findLocationById(Long id);
+    @Query("SELECT m.locationJpaEntity FROM MemberEntity m WHERE m.id = :id")
+    Optional<LocationEntity> findLocationById(Long id);
 
-    @Query("SELECT m.id FROM MemberJpaEntity m where m.nickname = :nickname")
+    @Query("SELECT m.id FROM MemberEntity m where m.nickname = :nickname")
     Optional<Long> findIdByNickname(String nickname);
 }

--- a/src/main/java/dandi/dandi/member/adapter/out/persistence/jpa/MemberRepository.java
+++ b/src/main/java/dandi/dandi/member/adapter/out/persistence/jpa/MemberRepository.java
@@ -27,16 +27,16 @@ public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
     void updateNickname(Long memberId, String nickname);
 
     @Modifying
-    @Query("UPDATE MemberEntity m SET m.locationJpaEntity.longitude = :longitude,"
-            + " m.locationJpaEntity.latitude = :latitude , m.locationJpaEntity.country = :country, "
-            + "m.locationJpaEntity.city = :city, m.locationJpaEntity.town = :town WHERE m.id = :memberId")
+    @Query("UPDATE MemberEntity m SET m.locationEntity.longitude = :longitude,"
+            + " m.locationEntity.latitude = :latitude , m.locationEntity.country = :country, "
+            + "m.locationEntity.city = :city, m.locationEntity.town = :town WHERE m.id = :memberId")
     void updateLocation(Long memberId, Double latitude, Double longitude, String country, String city, String town);
 
     @Query("SELECT m FROM MemberEntity m INNER JOIN PushNotificationJpaEntity pn ON m.id = pn.memberId "
             + "WHERE pn.allowance = true")
     Slice<MemberEntity> findPushNotificationAllowingMember(Pageable pageable);
 
-    @Query("SELECT m.locationJpaEntity FROM MemberEntity m WHERE m.id = :id")
+    @Query("SELECT m.locationEntity FROM MemberEntity m WHERE m.id = :id")
     Optional<LocationEntity> findLocationById(Long id);
 
     @Query("SELECT m.id FROM MemberEntity m where m.nickname = :nickname")

--- a/src/main/java/dandi/dandi/member/application/port/in/MemberBlockUseCasePort.java
+++ b/src/main/java/dandi/dandi/member/application/port/in/MemberBlockUseCasePort.java
@@ -1,0 +1,6 @@
+package dandi.dandi.member.application.port.in;
+
+public interface MemberBlockUseCasePort {
+
+    void blockMember(Long memberId, MemberBlockCommand memberBlockCommand);
+}

--- a/src/main/java/dandi/dandi/member/application/port/in/MemberImageUseCase.java
+++ b/src/main/java/dandi/dandi/member/application/port/in/MemberImageUseCase.java
@@ -2,7 +2,7 @@ package dandi.dandi.member.application.port.in;
 
 import org.springframework.web.multipart.MultipartFile;
 
-public interface ProfileImageUseCase {
+public interface MemberImageUseCase {
 
     ProfileImageUpdateResponse updateProfileImage(Long memberId, MultipartFile profileImage);
 }

--- a/src/main/java/dandi/dandi/member/application/port/in/MemberQueryServicePort.java
+++ b/src/main/java/dandi/dandi/member/application/port/in/MemberQueryServicePort.java
@@ -1,0 +1,8 @@
+package dandi.dandi.member.application.port.in;
+
+public interface MemberQueryServicePort {
+
+    MemberInfoResponse findMemberInfo(Long memberId);
+
+    NicknameDuplicationCheckResponse checkDuplication(Long memberId, String nickname);
+}

--- a/src/main/java/dandi/dandi/member/application/port/in/MemberUseCaseServicePort.java
+++ b/src/main/java/dandi/dandi/member/application/port/in/MemberUseCaseServicePort.java
@@ -1,14 +1,10 @@
 package dandi.dandi.member.application.port.in;
 
-public interface MemberUseCase {
-
-    MemberInfoResponse findMemberInfo(Long memberId);
+public interface MemberUseCaseServicePort {
 
     void updateNickname(Long memberId, NicknameUpdateCommand nicknameUpdateCommand);
 
     void updateLocation(Long memberId, LocationUpdateCommand locationUpdateCommand);
-
-    NicknameDuplicationCheckResponse checkDuplication(Long memberId, String nickname);
 
     void blockMember(Long memberId, MemberBlockCommand memberBlockCommand);
 }

--- a/src/main/java/dandi/dandi/member/application/port/in/MemberUseCaseServicePort.java
+++ b/src/main/java/dandi/dandi/member/application/port/in/MemberUseCaseServicePort.java
@@ -5,6 +5,4 @@ public interface MemberUseCaseServicePort {
     void updateNickname(Long memberId, NicknameUpdateCommand nicknameUpdateCommand);
 
     void updateLocation(Long memberId, LocationUpdateCommand locationUpdateCommand);
-
-    void blockMember(Long memberId, MemberBlockCommand memberBlockCommand);
 }

--- a/src/main/java/dandi/dandi/member/application/service/MemberBlockUseCaseServiceAdapter.java
+++ b/src/main/java/dandi/dandi/member/application/service/MemberBlockUseCaseServiceAdapter.java
@@ -1,0 +1,43 @@
+package dandi.dandi.member.application.service;
+
+import dandi.dandi.common.exception.NotFoundException;
+import dandi.dandi.member.application.port.in.MemberBlockCommand;
+import dandi.dandi.member.application.port.in.MemberBlockUseCasePort;
+import dandi.dandi.member.application.port.out.MemberBlockPersistencePort;
+import dandi.dandi.member.application.port.out.MemberPersistencePort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class MemberBlockUseCaseServiceAdapter implements MemberBlockUseCasePort {
+
+    private final MemberBlockPersistencePort memberBlockPersistencePort;
+    private final MemberPersistencePort memberPersistencePort;
+
+    public MemberBlockUseCaseServiceAdapter(MemberBlockPersistencePort memberBlockPersistencePort,
+                                            MemberPersistencePort memberPersistencePort) {
+        this.memberBlockPersistencePort = memberBlockPersistencePort;
+        this.memberPersistencePort = memberPersistencePort;
+    }
+
+    @Override
+    @Transactional
+    public void blockMember(Long memberId, MemberBlockCommand memberBlockCommand) {
+        Long blockedMemberId = memberBlockCommand.getBlockerMemberId();
+        validateMemberExistence(blockedMemberId);
+        validateAlreadyBlocked(memberId, blockedMemberId);
+        memberBlockPersistencePort.saveMemberBlockOf(memberId, blockedMemberId);
+    }
+
+    private void validateMemberExistence(Long blockedMemberId) {
+        if (!memberPersistencePort.existsById(blockedMemberId)) {
+            throw NotFoundException.member();
+        }
+    }
+
+    private void validateAlreadyBlocked(Long memberId, Long blockedMemberId) {
+        if (memberBlockPersistencePort.existsByBlockingMemberIdAndBlockedMemberId(memberId, blockedMemberId)) {
+            throw new IllegalStateException("이미 차단한 사용자입니다.");
+        }
+    }
+}

--- a/src/main/java/dandi/dandi/member/application/service/MemberImageService.java
+++ b/src/main/java/dandi/dandi/member/application/service/MemberImageService.java
@@ -4,8 +4,8 @@ import dandi.dandi.auth.exception.UnauthorizedException;
 import dandi.dandi.image.application.out.ImageManager;
 import dandi.dandi.image.exception.ImageDeletionFailedException;
 import dandi.dandi.image.exception.ImageUploadFailedException;
+import dandi.dandi.member.application.port.in.MemberImageUseCase;
 import dandi.dandi.member.application.port.in.ProfileImageUpdateResponse;
-import dandi.dandi.member.application.port.in.ProfileImageUseCase;
 import dandi.dandi.member.application.port.out.MemberPersistencePort;
 import dandi.dandi.member.domain.Member;
 import java.io.IOException;
@@ -18,9 +18,9 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
-public class ProfileImageService implements ProfileImageUseCase {
+public class MemberImageService implements MemberImageUseCase {
 
-    private static final Logger logger = LoggerFactory.getLogger(ProfileImageService.class);
+    private static final Logger logger = LoggerFactory.getLogger(MemberImageService.class);
 
     private static final String S3_FILE_KEY_FORMAT = "%s/%s_%s";
 
@@ -30,10 +30,10 @@ public class ProfileImageService implements ProfileImageUseCase {
     private final String profileImageDir;
     private final String imageAccessUrl;
 
-    public ProfileImageService(MemberPersistencePort memberPersistencePort, ImageManager imageManager,
-                               @Value("${image.member-initial-profile-image-url}") String initialProfileImageUrl,
-                               @Value("${image.profile-dir}") String profileImageDir,
-                               @Value("${cloud.aws.cloud-front.uri}") String imageAccessUrl) {
+    public MemberImageService(MemberPersistencePort memberPersistencePort, ImageManager imageManager,
+                              @Value("${image.member-initial-profile-image-url}") String initialProfileImageUrl,
+                              @Value("${image.profile-dir}") String profileImageDir,
+                              @Value("${cloud.aws.cloud-front.uri}") String imageAccessUrl) {
         this.memberPersistencePort = memberPersistencePort;
         this.imageManager = imageManager;
         this.initialProfileImageUrl = initialProfileImageUrl;

--- a/src/main/java/dandi/dandi/member/application/service/MemberImageService.java
+++ b/src/main/java/dandi/dandi/member/application/service/MemberImageService.java
@@ -79,8 +79,4 @@ public class MemberImageService implements MemberImageUseCase {
             logger.info("Profile Image Deletion Failed : " + currentProfileImageUrl);
         }
     }
-
-    public boolean isInitialProfileImage(String profileImage) {
-        return profileImage.equals(initialProfileImageUrl);
-    }
 }

--- a/src/main/java/dandi/dandi/member/application/service/MemberQueryServiceAdapter.java
+++ b/src/main/java/dandi/dandi/member/application/service/MemberQueryServiceAdapter.java
@@ -36,7 +36,6 @@ public class MemberQueryServiceAdapter implements MemberQueryServicePort {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public NicknameDuplicationCheckResponse checkDuplication(Long memberId, String nickname) {
         boolean duplicated = memberPersistencePort.existsMemberByNicknameExceptMine(memberId, nickname);
         return new NicknameDuplicationCheckResponse(duplicated);

--- a/src/main/java/dandi/dandi/member/application/service/MemberQueryServiceAdapter.java
+++ b/src/main/java/dandi/dandi/member/application/service/MemberQueryServiceAdapter.java
@@ -1,0 +1,44 @@
+package dandi.dandi.member.application.service;
+
+import dandi.dandi.auth.exception.UnauthorizedException;
+import dandi.dandi.member.application.port.in.MemberInfoResponse;
+import dandi.dandi.member.application.port.in.MemberQueryServicePort;
+import dandi.dandi.member.application.port.in.NicknameDuplicationCheckResponse;
+import dandi.dandi.member.application.port.out.MemberPersistencePort;
+import dandi.dandi.member.domain.Member;
+import dandi.dandi.post.application.port.out.MemberPostPersistencePort;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class MemberQueryServiceAdapter implements MemberQueryServicePort {
+
+    private final MemberPersistencePort memberPersistencePort;
+    private final MemberPostPersistencePort memberPostPersistencePort;
+    private final String imageAccessUrl;
+
+    public MemberQueryServiceAdapter(MemberPersistencePort memberPersistencePort,
+                                     MemberPostPersistencePort memberPostPersistencePort,
+                                     @Value("${cloud.aws.cloud-front.uri}") String imageAccessUrl) {
+        this.memberPersistencePort = memberPersistencePort;
+        this.memberPostPersistencePort = memberPostPersistencePort;
+        this.imageAccessUrl = imageAccessUrl;
+    }
+
+    @Override
+    public MemberInfoResponse findMemberInfo(Long memberId) {
+        Member member = memberPersistencePort.findById(memberId)
+                .orElseThrow(UnauthorizedException::notExistentMember);
+        int postCount = memberPostPersistencePort.countPostByMemberId(memberId);
+        return new MemberInfoResponse(member, postCount, imageAccessUrl);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public NicknameDuplicationCheckResponse checkDuplication(Long memberId, String nickname) {
+        boolean duplicated = memberPersistencePort.existsMemberByNicknameExceptMine(memberId, nickname);
+        return new NicknameDuplicationCheckResponse(duplicated);
+    }
+}

--- a/src/main/java/dandi/dandi/member/application/service/MemberUseCaseServiceAdapter.java
+++ b/src/main/java/dandi/dandi/member/application/service/MemberUseCaseServiceAdapter.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 public class MemberUseCaseServiceAdapter implements MemberUseCaseServicePort {
 
     private final MemberPersistencePort memberPersistencePort;
@@ -31,7 +32,6 @@ public class MemberUseCaseServiceAdapter implements MemberUseCaseServicePort {
     }
 
     @Override
-    @Transactional
     public void updateNickname(Long memberId, NicknameUpdateCommand nicknameUpdateCommand) {
         Member member = findMember(memberId);
         try {
@@ -42,7 +42,6 @@ public class MemberUseCaseServiceAdapter implements MemberUseCaseServicePort {
     }
 
     @Override
-    @Transactional
     public void updateLocation(Long memberId, LocationUpdateCommand locationUpdateCommand) {
         Member member = findMember(memberId);
         Location location = new Location(locationUpdateCommand.getLatitude(), locationUpdateCommand.getLongitude(),
@@ -56,7 +55,6 @@ public class MemberUseCaseServiceAdapter implements MemberUseCaseServicePort {
     }
 
     @Override
-    @Transactional
     public void blockMember(Long memberId, MemberBlockCommand memberBlockCommand) {
         Long blockedMemberId = memberBlockCommand.getBlockerMemberId();
         validateMemberExistence(blockedMemberId);

--- a/src/main/java/dandi/dandi/member/application/service/MemberUseCaseServiceAdapter.java
+++ b/src/main/java/dandi/dandi/member/application/service/MemberUseCaseServiceAdapter.java
@@ -1,12 +1,9 @@
 package dandi.dandi.member.application.service;
 
 import dandi.dandi.auth.exception.UnauthorizedException;
-import dandi.dandi.common.exception.NotFoundException;
 import dandi.dandi.member.application.port.in.LocationUpdateCommand;
-import dandi.dandi.member.application.port.in.MemberBlockCommand;
 import dandi.dandi.member.application.port.in.MemberUseCaseServicePort;
 import dandi.dandi.member.application.port.in.NicknameUpdateCommand;
-import dandi.dandi.member.application.port.out.MemberBlockPersistencePort;
 import dandi.dandi.member.application.port.out.MemberPersistencePort;
 import dandi.dandi.member.domain.DistrictParser;
 import dandi.dandi.member.domain.Location;
@@ -20,14 +17,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberUseCaseServiceAdapter implements MemberUseCaseServicePort {
 
     private final MemberPersistencePort memberPersistencePort;
-    private final MemberBlockPersistencePort memberBlockPersistencePort;
     private final DistrictParser districtParser;
 
     public MemberUseCaseServiceAdapter(MemberPersistencePort memberPersistencePort,
-                                       MemberBlockPersistencePort memberBlockPersistencePort,
                                        DistrictParser districtParser) {
         this.memberPersistencePort = memberPersistencePort;
-        this.memberBlockPersistencePort = memberBlockPersistencePort;
         this.districtParser = districtParser;
     }
 
@@ -52,25 +46,5 @@ public class MemberUseCaseServiceAdapter implements MemberUseCaseServicePort {
     private Member findMember(Long memberId) {
         return memberPersistencePort.findById(memberId)
                 .orElseThrow(UnauthorizedException::notExistentMember);
-    }
-
-    @Override
-    public void blockMember(Long memberId, MemberBlockCommand memberBlockCommand) {
-        Long blockedMemberId = memberBlockCommand.getBlockerMemberId();
-        validateMemberExistence(blockedMemberId);
-        validateAlreadyBlocked(memberId, blockedMemberId);
-        memberBlockPersistencePort.saveMemberBlockOf(memberId, blockedMemberId);
-    }
-
-    private void validateMemberExistence(Long blockedMemberId) {
-        if (!memberPersistencePort.existsById(blockedMemberId)) {
-            throw NotFoundException.member();
-        }
-    }
-
-    private void validateAlreadyBlocked(Long memberId, Long blockedMemberId) {
-        if (memberBlockPersistencePort.existsByBlockingMemberIdAndBlockedMemberId(memberId, blockedMemberId)) {
-            throw new IllegalStateException("이미 차단한 사용자입니다.");
-        }
     }
 }

--- a/src/main/java/dandi/dandi/member/web/MemberBlockController.java
+++ b/src/main/java/dandi/dandi/member/web/MemberBlockController.java
@@ -1,0 +1,26 @@
+package dandi.dandi.member.web;
+
+import dandi.dandi.auth.web.support.Login;
+import dandi.dandi.member.application.port.in.MemberBlockCommand;
+import dandi.dandi.member.application.port.in.MemberBlockUseCasePort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class MemberBlockController implements MemberBlockControllerDocs {
+
+    private final MemberBlockUseCasePort memberBlockUseCasePort;
+
+    public MemberBlockController(MemberBlockUseCasePort memberBlockUseCasePort) {
+        this.memberBlockUseCasePort = memberBlockUseCasePort;
+    }
+
+    @PostMapping("/members/blocks")
+    public ResponseEntity<Void> blockMember(@Login Long memberId, @RequestBody MemberBlockCommand memberBlockCommand) {
+        memberBlockUseCasePort.blockMember(memberId, memberBlockCommand);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+}

--- a/src/main/java/dandi/dandi/member/web/MemberBlockControllerDocs.java
+++ b/src/main/java/dandi/dandi/member/web/MemberBlockControllerDocs.java
@@ -1,0 +1,21 @@
+package dandi.dandi.member.web;
+
+import dandi.dandi.member.application.port.in.MemberBlockCommand;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "회원체계")
+public interface MemberBlockControllerDocs {
+
+    @Operation(summary = "사용자 차단")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "사용자 차단 성공"),
+            @ApiResponse(responseCode = "400", description = "이미 차단한 사용자"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 사용자 사용자"),
+    })
+    ResponseEntity<Void> blockMember(@Parameter(hidden = true) Long memberId, MemberBlockCommand memberBlockCommand);
+}

--- a/src/main/java/dandi/dandi/member/web/MemberController.java
+++ b/src/main/java/dandi/dandi/member/web/MemberController.java
@@ -5,34 +5,26 @@ import dandi.dandi.member.application.port.in.MemberBlockCommand;
 import dandi.dandi.member.application.port.in.MemberInfoResponse;
 import dandi.dandi.member.application.port.in.MemberUseCase;
 import dandi.dandi.member.application.port.in.NicknameDuplicationCheckResponse;
-import dandi.dandi.member.application.port.in.ProfileImageUpdateResponse;
-import dandi.dandi.member.application.port.in.ProfileImageUseCase;
 import dandi.dandi.member.web.dto.in.LocationUpdateRequest;
 import dandi.dandi.member.web.dto.in.NicknameUpdateRequest;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/members")
 public class MemberController implements MemberControllerDocs {
 
     private final MemberUseCase memberUseCase;
-    private final ProfileImageUseCase profileImageUseCase;
 
-    public MemberController(MemberUseCase memberUseCase, ProfileImageUseCase profileImageUseCase) {
+    public MemberController(MemberUseCase memberUseCase) {
         this.memberUseCase = memberUseCase;
-        this.profileImageUseCase = profileImageUseCase;
     }
 
     @GetMapping
@@ -58,13 +50,6 @@ public class MemberController implements MemberControllerDocs {
                                                      @RequestBody LocationUpdateRequest locationUpdateRequest) {
         memberUseCase.updateLocation(memberId, locationUpdateRequest.toCommand());
         return ResponseEntity.noContent().build();
-    }
-
-    @PutMapping(path = "/profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ProfileImageUpdateResponse> updateMemberProfileImage(@Login Long memberId,
-                                                                               @RequestPart(value = "profileImage")
-                                                                               MultipartFile profileImage) {
-        return ResponseEntity.ok(profileImageUseCase.updateProfileImage(memberId, profileImage));
     }
 
     @PostMapping("/blocks")

--- a/src/main/java/dandi/dandi/member/web/MemberController.java
+++ b/src/main/java/dandi/dandi/member/web/MemberController.java
@@ -3,7 +3,8 @@ package dandi.dandi.member.web;
 import dandi.dandi.auth.web.support.Login;
 import dandi.dandi.member.application.port.in.MemberBlockCommand;
 import dandi.dandi.member.application.port.in.MemberInfoResponse;
-import dandi.dandi.member.application.port.in.MemberUseCase;
+import dandi.dandi.member.application.port.in.MemberQueryServicePort;
+import dandi.dandi.member.application.port.in.MemberUseCaseServicePort;
 import dandi.dandi.member.application.port.in.NicknameDuplicationCheckResponse;
 import dandi.dandi.member.web.dto.in.LocationUpdateRequest;
 import dandi.dandi.member.web.dto.in.NicknameUpdateRequest;
@@ -21,40 +22,43 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/members")
 public class MemberController implements MemberControllerDocs {
 
-    private final MemberUseCase memberUseCase;
+    private final MemberUseCaseServicePort memberUseCaseServicePort;
+    private final MemberQueryServicePort memberQueryServicePort;
 
-    public MemberController(MemberUseCase memberUseCase) {
-        this.memberUseCase = memberUseCase;
+    public MemberController(MemberUseCaseServicePort memberUseCaseServicePort,
+                            MemberQueryServicePort memberQueryServicePort) {
+        this.memberUseCaseServicePort = memberUseCaseServicePort;
+        this.memberQueryServicePort = memberQueryServicePort;
     }
 
     @GetMapping
     public ResponseEntity<MemberInfoResponse> getMemberInfo(@Login Long memberId) {
-        return ResponseEntity.ok(memberUseCase.findMemberInfo(memberId));
+        return ResponseEntity.ok(memberQueryServicePort.findMemberInfo(memberId));
     }
 
     @GetMapping(value = "/nickname/duplication", params = "nickname")
     public ResponseEntity<NicknameDuplicationCheckResponse> checkNicknameDuplication(@Login Long memberId,
                                                                                      @RequestParam String nickname) {
-        return ResponseEntity.ok(memberUseCase.checkDuplication(memberId, nickname));
+        return ResponseEntity.ok(memberQueryServicePort.checkDuplication(memberId, nickname));
     }
 
     @PatchMapping("/nickname")
     public ResponseEntity<Void> updateMemberNickname(@Login Long memberId,
                                                      @RequestBody NicknameUpdateRequest nicknameUpdateRequest) {
-        memberUseCase.updateNickname(memberId, nicknameUpdateRequest.toCommand());
+        memberUseCaseServicePort.updateNickname(memberId, nicknameUpdateRequest.toCommand());
         return ResponseEntity.noContent().build();
     }
 
     @PatchMapping("/location")
     public ResponseEntity<Void> updateMemberLocation(@Login Long memberId,
                                                      @RequestBody LocationUpdateRequest locationUpdateRequest) {
-        memberUseCase.updateLocation(memberId, locationUpdateRequest.toCommand());
+        memberUseCaseServicePort.updateLocation(memberId, locationUpdateRequest.toCommand());
         return ResponseEntity.noContent().build();
     }
 
     @PostMapping("/blocks")
     public ResponseEntity<Void> blockMember(@Login Long memberId, @RequestBody MemberBlockCommand memberBlockCommand) {
-        memberUseCase.blockMember(memberId, memberBlockCommand);
+        memberUseCaseServicePort.blockMember(memberId, memberBlockCommand);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 }

--- a/src/main/java/dandi/dandi/member/web/MemberController.java
+++ b/src/main/java/dandi/dandi/member/web/MemberController.java
@@ -1,18 +1,15 @@
 package dandi.dandi.member.web;
 
 import dandi.dandi.auth.web.support.Login;
-import dandi.dandi.member.application.port.in.MemberBlockCommand;
 import dandi.dandi.member.application.port.in.MemberInfoResponse;
 import dandi.dandi.member.application.port.in.MemberQueryServicePort;
 import dandi.dandi.member.application.port.in.MemberUseCaseServicePort;
 import dandi.dandi.member.application.port.in.NicknameDuplicationCheckResponse;
 import dandi.dandi.member.web.dto.in.LocationUpdateRequest;
 import dandi.dandi.member.web.dto.in.NicknameUpdateRequest;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -54,11 +51,5 @@ public class MemberController implements MemberControllerDocs {
                                                      @RequestBody LocationUpdateRequest locationUpdateRequest) {
         memberUseCaseServicePort.updateLocation(memberId, locationUpdateRequest.toCommand());
         return ResponseEntity.noContent().build();
-    }
-
-    @PostMapping("/blocks")
-    public ResponseEntity<Void> blockMember(@Login Long memberId, @RequestBody MemberBlockCommand memberBlockCommand) {
-        memberUseCaseServicePort.blockMember(memberId, memberBlockCommand);
-        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 }

--- a/src/main/java/dandi/dandi/member/web/MemberControllerDocs.java
+++ b/src/main/java/dandi/dandi/member/web/MemberControllerDocs.java
@@ -1,30 +1,23 @@
 package dandi.dandi.member.web;
 
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
-import static org.springframework.http.MediaType.IMAGE_JPEG_VALUE;
 
 import dandi.dandi.advice.ExceptionResponse;
 import dandi.dandi.member.application.port.in.MemberBlockCommand;
 import dandi.dandi.member.application.port.in.MemberInfoResponse;
 import dandi.dandi.member.application.port.in.NicknameDuplicationCheckResponse;
-import dandi.dandi.member.application.port.in.ProfileImageUpdateResponse;
 import dandi.dandi.member.web.dto.in.LocationUpdateRequest;
 import dandi.dandi.member.web.dto.in.NicknameUpdateRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Encoding;
 import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "회원체계")
 public interface MemberControllerDocs {
@@ -56,27 +49,6 @@ public interface MemberControllerDocs {
     })
     ResponseEntity<Void> updateMemberLocation(@Parameter(hidden = true) Long memberId,
                                               LocationUpdateRequest locationUpdateRequest);
-
-    @Operation(summary = "프로필 사진 변경", parameters = {
-            @Parameter(name = AUTHORIZATION, in = ParameterIn.HEADER, required = true, example = "Bearer ${token}"),
-            @Parameter(name = CONTENT_TYPE, in = ParameterIn.HEADER, required = true, example = "multipart/form-data; boundary=------AaB03x")},
-            requestBody =
-            @RequestBody(content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
-                    schema = @Schema(pattern =
-                            "------AaB03x\t\n"
-                                    + "Content-Disposition: form-data; name = profileImage; filename = test_img.jpg\t\n"
-                                    + "Content-Type: application/octet-stream\t\n"
-                                    + "\t\n"
-                                    + "파일\t\n"
-                                    + "------AaB03x"), encoding = @Encoding(name = "profileImage", contentType = IMAGE_JPEG_VALUE)))
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "프로필 사진 정상 변경", content = @Content(schema = @Schema(implementation = ProfileImageUpdateResponse.class))),
-            @ApiResponse(responseCode = "500", description = "프로필 사진 변경 실패",
-                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class)))
-    })
-    ResponseEntity<ProfileImageUpdateResponse> updateMemberProfileImage(@Parameter(hidden = true) Long memberId,
-                                                                        @Parameter(hidden = true) MultipartFile profileImage);
 
     @Operation(summary = "사용자 차단")
     @ApiResponses(value = {

--- a/src/main/java/dandi/dandi/member/web/MemberControllerDocs.java
+++ b/src/main/java/dandi/dandi/member/web/MemberControllerDocs.java
@@ -3,7 +3,6 @@ package dandi.dandi.member.web;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 import dandi.dandi.advice.ExceptionResponse;
-import dandi.dandi.member.application.port.in.MemberBlockCommand;
 import dandi.dandi.member.application.port.in.MemberInfoResponse;
 import dandi.dandi.member.application.port.in.NicknameDuplicationCheckResponse;
 import dandi.dandi.member.web.dto.in.LocationUpdateRequest;
@@ -49,12 +48,4 @@ public interface MemberControllerDocs {
     })
     ResponseEntity<Void> updateMemberLocation(@Parameter(hidden = true) Long memberId,
                                               LocationUpdateRequest locationUpdateRequest);
-
-    @Operation(summary = "사용자 차단")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "201", description = "사용자 차단 성공"),
-            @ApiResponse(responseCode = "400", description = "이미 차단한 사용자"),
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 사용자 사용자"),
-    })
-    ResponseEntity<Void> blockMember(@Parameter(hidden = true) Long memberId, MemberBlockCommand memberBlockCommand);
 }

--- a/src/main/java/dandi/dandi/member/web/MemberImageController.java
+++ b/src/main/java/dandi/dandi/member/web/MemberImageController.java
@@ -1,0 +1,28 @@
+package dandi.dandi.member.web;
+
+import dandi.dandi.auth.web.support.Login;
+import dandi.dandi.member.application.port.in.MemberImageUseCase;
+import dandi.dandi.member.application.port.in.ProfileImageUpdateResponse;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+public class MemberImageController implements MemberImageControllerDocs {
+
+    private final MemberImageUseCase memberImageUseCase;
+
+    public MemberImageController(MemberImageUseCase memberImageUseCase) {
+        this.memberImageUseCase = memberImageUseCase;
+    }
+
+    @PutMapping(path = "/members/profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ProfileImageUpdateResponse> updateMemberProfileImage(@Login Long memberId,
+                                                                               @RequestPart(value = "profileImage")
+                                                                               MultipartFile profileImage) {
+        return ResponseEntity.ok(memberImageUseCase.updateProfileImage(memberId, profileImage));
+    }
+}

--- a/src/main/java/dandi/dandi/member/web/MemberImageControllerDocs.java
+++ b/src/main/java/dandi/dandi/member/web/MemberImageControllerDocs.java
@@ -15,10 +15,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.multipart.MultipartFile;
 
+@Tag(name = "회원체계")
 public interface MemberImageControllerDocs {
 
     @Operation(summary = "프로필 사진 변경", parameters = {

--- a/src/main/java/dandi/dandi/member/web/MemberImageControllerDocs.java
+++ b/src/main/java/dandi/dandi/member/web/MemberImageControllerDocs.java
@@ -1,0 +1,44 @@
+package dandi.dandi.member.web;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+import static org.springframework.http.MediaType.IMAGE_JPEG_VALUE;
+
+import dandi.dandi.advice.ExceptionResponse;
+import dandi.dandi.member.application.port.in.ProfileImageUpdateResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Encoding;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface MemberImageControllerDocs {
+
+    @Operation(summary = "프로필 사진 변경", parameters = {
+            @Parameter(name = AUTHORIZATION, in = ParameterIn.HEADER, required = true, example = "Bearer ${token}"),
+            @Parameter(name = CONTENT_TYPE, in = ParameterIn.HEADER, required = true, example = "multipart/form-data; boundary=------AaB03x")},
+            requestBody =
+            @RequestBody(content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                    schema = @Schema(pattern =
+                            "------AaB03x\t\n"
+                                    + "Content-Disposition: form-data; name = profileImage; filename = test_img.jpg\t\n"
+                                    + "Content-Type: application/octet-stream\t\n"
+                                    + "\t\n"
+                                    + "파일\t\n"
+                                    + "------AaB03x"), encoding = @Encoding(name = "profileImage", contentType = IMAGE_JPEG_VALUE)))
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "프로필 사진 정상 변경", content = @Content(schema = @Schema(implementation = ProfileImageUpdateResponse.class))),
+            @ApiResponse(responseCode = "500", description = "프로필 사진 변경 실패",
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class)))
+    })
+    ResponseEntity<ProfileImageUpdateResponse> updateMemberProfileImage(@Parameter(hidden = true) Long memberId,
+                                                                        @Parameter(hidden = true) MultipartFile profileImage);
+}

--- a/src/main/java/dandi/dandi/post/adapter/out/PostPersistenceAdapter.java
+++ b/src/main/java/dandi/dandi/post/adapter/out/PostPersistenceAdapter.java
@@ -1,7 +1,7 @@
 package dandi.dandi.post.adapter.out;
 
 import dandi.dandi.advice.InternalServerException;
-import dandi.dandi.member.adapter.out.persistence.MemberRepository;
+import dandi.dandi.member.adapter.out.persistence.jpa.MemberRepository;
 import dandi.dandi.member.domain.Member;
 import dandi.dandi.post.application.port.out.PostPersistencePort;
 import dandi.dandi.post.domain.Post;

--- a/src/main/java/dandi/dandi/post/adapter/out/PostRepository.java
+++ b/src/main/java/dandi/dandi/post/adapter/out/PostRepository.java
@@ -15,8 +15,8 @@ public interface PostRepository extends JpaRepository<PostJpaEntity, Long> {
             + "p.minTemperature BETWEEN :minTemperatureMinSearchCondition AND :minTemperatureMaxSearchCondition AND "
             + "p.maxTemperature BETWEEN :maxTemperatureMinSearchCondition AND :maxTemperatureMaxSearchCondition AND "
             + "p.id NOT IN (SELECT pr.postId FROM PostReportJpaEntity pr WHERE pr.memberId = :memberId) AND "
-            + "p.memberId NOT IN (SELECT mb.blockedMemberId FROM MemberBlockJpaEntity mb where mb.blockingMemberId = :memberId) AND "
-            + "p.memberId NOT IN (SELECT mb.blockingMemberId FROM MemberBlockJpaEntity mb WHERE mb.blockedMemberId = :memberId )")
+            + "p.memberId NOT IN (SELECT mb.blockedMemberId FROM MemberBlockEntity mb where mb.blockingMemberId = :memberId) AND "
+            + "p.memberId NOT IN (SELECT mb.blockingMemberId FROM MemberBlockEntity mb WHERE mb.blockedMemberId = :memberId )")
     Slice<PostJpaEntity> findByTemperature(Long memberId, Double minTemperatureMinSearchCondition,
                                            Double minTemperatureMaxSearchCondition,
                                            Double maxTemperatureMinSearchCondition,

--- a/src/test/java/dandi/dandi/comment/adapter/persistence/CommentPersistenceAdapterTest.java
+++ b/src/test/java/dandi/dandi/comment/adapter/persistence/CommentPersistenceAdapterTest.java
@@ -12,8 +12,8 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import dandi.dandi.comment.domain.Comment;
 import dandi.dandi.common.PersistenceAdapterTest;
-import dandi.dandi.member.adapter.out.persistence.MemberBlockPersistenceAdapter;
-import dandi.dandi.member.adapter.out.persistence.MemberPersistenceAdapter;
+import dandi.dandi.member.adapter.out.persistence.jpa.MemberBlockPersistenceAdapter;
+import dandi.dandi.member.adapter.out.persistence.jpa.MemberPersistenceAdapter;
 import dandi.dandi.member.domain.Member;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/dandi/dandi/image/acceptance/ImageAcceptanceTest.java
+++ b/src/test/java/dandi/dandi/image/acceptance/ImageAcceptanceTest.java
@@ -18,7 +18,6 @@ class ImageAcceptanceTest extends AcceptanceTest {
 
     @DisplayName("1MB 보다 큰 사진 파일을 등록하려 하면 400을 응답한다.")
     @Test
-    @Disabled
     void postImage_BadRequest() {
         String token = getToken();
         File file = new File(new File("")

--- a/src/test/java/dandi/dandi/member/MemberTestFixture.java
+++ b/src/test/java/dandi/dandi/member/MemberTestFixture.java
@@ -1,6 +1,6 @@
 package dandi.dandi.member;
 
-import dandi.dandi.member.adapter.out.persistence.MemberJpaEntity;
+import dandi.dandi.member.adapter.out.persistence.jpa.MemberEntity;
 import dandi.dandi.member.domain.District;
 import dandi.dandi.member.domain.Location;
 import dandi.dandi.member.domain.Member;
@@ -19,7 +19,7 @@ public class MemberTestFixture {
             MEMBER_ID, OAUTH_ID, NICKNAME, new Location(0.0, 0.0, DISTRICT), INITIAL_PROFILE_IMAGE_URL);
     public static final Member MEMBER2 = new Member(
             2L, "oAuthId2", "nickname2", new Location(0.0, 0.0, DISTRICT), INITIAL_PROFILE_IMAGE_URL);
-    public static final MemberJpaEntity MEMBER_JPA_ENTITY = MemberJpaEntity.fromMember(new Member(
+    public static final MemberEntity MEMBER_JPA_ENTITY = MemberEntity.fromMember(new Member(
             MEMBER_ID, OAUTH_ID, NICKNAME, new Location(0.0, 0.0, DISTRICT), INITIAL_PROFILE_IMAGE_URL));
 
 }

--- a/src/test/java/dandi/dandi/member/adapter/out/persistence/MemberPersistenceAdapterTest.java
+++ b/src/test/java/dandi/dandi/member/adapter/out/persistence/MemberPersistenceAdapterTest.java
@@ -192,8 +192,8 @@ class MemberPersistenceAdapterTest extends PersistenceAdapterTest {
     @DisplayName("닉네임으로 회원 id를 찾을 수 있다.")
     @Test
     void findIdByNickname() {
-        Member member = memberPersistenceAdapter.save(
-                new Member(null, OAUTH_ID, NICKNAME, new Location(10, 10), INITIAL_PROFILE_IMAGE_URL));
+        memberPersistenceAdapter.save(
+                new Member(null, OAUTH_ID, NICKNAME, Location.initial(), INITIAL_PROFILE_IMAGE_URL));
 
         Optional<Long> actual = memberPersistenceAdapter.findIdByNickname(NICKNAME);
 

--- a/src/test/java/dandi/dandi/member/adapter/out/persistence/jpa/MemberBlockPersistenceAdapterTest.java
+++ b/src/test/java/dandi/dandi/member/adapter/out/persistence/jpa/MemberBlockPersistenceAdapterTest.java
@@ -1,4 +1,4 @@
-package dandi.dandi.member.adapter.out.persistence;
+package dandi.dandi.member.adapter.out.persistence.jpa;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;

--- a/src/test/java/dandi/dandi/member/adapter/out/persistence/jpa/MemberPersistenceAdapterTest.java
+++ b/src/test/java/dandi/dandi/member/adapter/out/persistence/jpa/MemberPersistenceAdapterTest.java
@@ -1,4 +1,4 @@
-package dandi.dandi.member.adapter.out.persistence;
+package dandi.dandi.member.adapter.out.persistence.jpa;
 
 import static dandi.dandi.member.MemberTestFixture.DISTRICT;
 import static dandi.dandi.member.MemberTestFixture.INITIAL_PROFILE_IMAGE_URL;

--- a/src/test/java/dandi/dandi/member/adapter/out/persistence/jpa/MemberPostPersistenceAdapterTest.java
+++ b/src/test/java/dandi/dandi/member/adapter/out/persistence/jpa/MemberPostPersistenceAdapterTest.java
@@ -1,4 +1,4 @@
-package dandi.dandi.member.adapter.out.persistence;
+package dandi.dandi.member.adapter.out.persistence.jpa;
 
 import static dandi.dandi.member.MemberTestFixture.MEMBER_ID;
 import static dandi.dandi.post.PostFixture.POST_IMAGE_URL;
@@ -7,9 +7,7 @@ import static dandi.dandi.post.PostFixture.WEATHER_FEELING;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import dandi.dandi.common.PersistenceAdapterTest;
-import dandi.dandi.post.PostFixture;
 import dandi.dandi.post.adapter.out.PostPersistenceAdapter;
-import dandi.dandi.post.adapter.out.PostRepository;
 import dandi.dandi.post.domain.Post;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/dandi/dandi/member/application/MemberImageServiceTest.java
+++ b/src/test/java/dandi/dandi/member/application/MemberImageServiceTest.java
@@ -20,7 +20,7 @@ import dandi.dandi.auth.exception.UnauthorizedException;
 import dandi.dandi.image.application.out.ImageManager;
 import dandi.dandi.image.exception.ImageUploadFailedException;
 import dandi.dandi.member.application.port.out.MemberPersistencePort;
-import dandi.dandi.member.application.service.ProfileImageService;
+import dandi.dandi.member.application.service.MemberImageService;
 import dandi.dandi.member.domain.Member;
 import java.io.IOException;
 import java.util.Optional;
@@ -31,7 +31,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class ProfileImageServiceTest {
+class MemberImageServiceTest {
 
     private static final String NOT_INITIAL_PROFILE_IMAGE_URL = "notInitialProfileImageUrl";
 
@@ -39,7 +39,7 @@ class ProfileImageServiceTest {
 
     private final MemberPersistencePort memberPersistencePort = Mockito.mock(MemberPersistencePort.class);
     private final ImageManager imageManager = Mockito.mock(ImageManager.class);
-    private final ProfileImageService profileImageService = new ProfileImageService(memberPersistencePort,
+    private final MemberImageService profileImageService = new MemberImageService(memberPersistencePort,
             imageManager, INITIAL_PROFILE_IMAGE_URL, TEST_PROFILE_BUCKET_IMG_DIR, IMAGE_ACCESS_URL);
 
     @DisplayName("기본 프로필 사진이 아닌 회원의 프로필 사진을 변경하면 기존 사진을 삭제하고 사진을 업로드 한 후, 사진의 식별값을 반환한다.")

--- a/src/test/java/dandi/dandi/member/application/service/MemberBlockUseCaseServiceAdapterTest.java
+++ b/src/test/java/dandi/dandi/member/application/service/MemberBlockUseCaseServiceAdapterTest.java
@@ -1,0 +1,70 @@
+package dandi.dandi.member.application.service;
+
+import static dandi.dandi.member.MemberTestFixture.MEMBER_ID;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import dandi.dandi.common.exception.NotFoundException;
+import dandi.dandi.member.application.port.in.MemberBlockCommand;
+import dandi.dandi.member.application.port.out.MemberBlockPersistencePort;
+import dandi.dandi.member.application.port.out.MemberPersistencePort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MemberBlockUseCaseServiceAdapterTest {
+
+    @Mock
+    private MemberBlockPersistencePort memberBlockPersistencePort;
+    @Mock
+    private MemberPersistencePort memberPersistencePort;
+    @InjectMocks
+    private MemberBlockUseCaseServiceAdapter memberBlockUseCaseServiceAdapter;
+
+    @DisplayName("존재하지 않는 id의 사용자를 차단하려고 하면 예외를 발생시킨다.")
+    @Test
+    void blockMember_NotFound() {
+        Long blockedMemberId = 2L;
+        when(memberPersistencePort.existsById(blockedMemberId))
+                .thenReturn(false);
+
+        assertThatThrownBy(
+                () -> memberBlockUseCaseServiceAdapter.blockMember(MEMBER_ID, new MemberBlockCommand(blockedMemberId)))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage(NotFoundException.member().getMessage());
+    }
+
+    @DisplayName("이미 차단한 사용자를 차단하려고 하면 예외를 발생시킨다.")
+    @Test
+    void blockMember_AlreadyBlocked() {
+        Long blockedMemberId = 2L;
+        when(memberPersistencePort.existsById(blockedMemberId))
+                .thenReturn(true);
+        when(memberBlockPersistencePort.existsByBlockingMemberIdAndBlockedMemberId(MEMBER_ID, blockedMemberId))
+                .thenReturn(true);
+
+        assertThatThrownBy(
+                () -> memberBlockUseCaseServiceAdapter.blockMember(MEMBER_ID, new MemberBlockCommand(blockedMemberId)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("이미 차단한 사용자입니다.");
+    }
+
+    @DisplayName("다른 사용자를 차단할 수 있다.")
+    @Test
+    void blockMember() {
+        Long blockedMemberId = 2L;
+        when(memberPersistencePort.existsById(blockedMemberId))
+                .thenReturn(true);
+        when(memberBlockPersistencePort.existsByBlockingMemberIdAndBlockedMemberId(MEMBER_ID, blockedMemberId))
+                .thenReturn(false);
+
+        memberBlockUseCaseServiceAdapter.blockMember(MEMBER_ID, new MemberBlockCommand(blockedMemberId));
+
+        verify(memberBlockPersistencePort).saveMemberBlockOf(MEMBER_ID, blockedMemberId);
+    }
+}

--- a/src/test/java/dandi/dandi/member/application/service/MemberImageServiceTest.java
+++ b/src/test/java/dandi/dandi/member/application/service/MemberImageServiceTest.java
@@ -1,4 +1,4 @@
-package dandi.dandi.member.application;
+package dandi.dandi.member.application.service;
 
 import static dandi.dandi.member.MemberTestFixture.INITIAL_PROFILE_IMAGE_URL;
 import static dandi.dandi.member.MemberTestFixture.NICKNAME;
@@ -20,7 +20,6 @@ import dandi.dandi.auth.exception.UnauthorizedException;
 import dandi.dandi.image.application.out.ImageManager;
 import dandi.dandi.image.exception.ImageUploadFailedException;
 import dandi.dandi.member.application.port.out.MemberPersistencePort;
-import dandi.dandi.member.application.service.MemberImageService;
 import dandi.dandi.member.domain.Member;
 import java.io.IOException;
 import java.util.Optional;
@@ -39,8 +38,8 @@ class MemberImageServiceTest {
 
     private final MemberPersistencePort memberPersistencePort = Mockito.mock(MemberPersistencePort.class);
     private final ImageManager imageManager = Mockito.mock(ImageManager.class);
-    private final MemberImageService profileImageService = new MemberImageService(memberPersistencePort,
-            imageManager, INITIAL_PROFILE_IMAGE_URL, TEST_PROFILE_BUCKET_IMG_DIR, IMAGE_ACCESS_URL);
+    private final MemberImageService memberImageService = new MemberImageService(memberPersistencePort, imageManager,
+            INITIAL_PROFILE_IMAGE_URL, TEST_PROFILE_BUCKET_IMG_DIR, IMAGE_ACCESS_URL);
 
     @DisplayName("기본 프로필 사진이 아닌 회원의 프로필 사진을 변경하면 기존 사진을 삭제하고 사진을 업로드 한 후, 사진의 식별값을 반환한다.")
     @Test
@@ -50,7 +49,7 @@ class MemberImageServiceTest {
         when(memberPersistencePort.findById(memberId))
                 .thenReturn(Optional.of(initialProfileImageMember));
 
-        String imgUrl = profileImageService.updateProfileImage(memberId, generateTestImgMultipartFile())
+        String imgUrl = memberImageService.updateProfileImage(memberId, generateTestImgMultipartFile())
                 .getProfileImageUrl();
 
         assertAll(
@@ -68,7 +67,7 @@ class MemberImageServiceTest {
         when(memberPersistencePort.findById(memberId))
                 .thenReturn(Optional.of(Member.initial(OAUTH_ID, NICKNAME, INITIAL_PROFILE_IMAGE_URL)));
 
-        String imgUrl = profileImageService.updateProfileImage(memberId, generateTestImgMultipartFile())
+        String imgUrl = memberImageService.updateProfileImage(memberId, generateTestImgMultipartFile())
                 .getProfileImageUrl();
 
         assertAll(
@@ -87,7 +86,7 @@ class MemberImageServiceTest {
                 .when(imageManager)
                 .upload(anyString(), any());
 
-        assertThatThrownBy(() -> profileImageService.updateProfileImage(memberId, generateTestImgMultipartFile()))
+        assertThatThrownBy(() -> memberImageService.updateProfileImage(memberId, generateTestImgMultipartFile()))
                 .isInstanceOf(ImageUploadFailedException.class);
     }
 
@@ -99,7 +98,7 @@ class MemberImageServiceTest {
                 .thenReturn(Optional.empty());
 
         assertThatThrownBy(
-                () -> profileImageService.updateProfileImage(notExistentMemberId, generateTestImgMultipartFile()))
+                () -> memberImageService.updateProfileImage(notExistentMemberId, generateTestImgMultipartFile()))
                 .isInstanceOf(UnauthorizedException.class)
                 .hasMessage(UnauthorizedException.notExistentMember().getMessage());
     }

--- a/src/test/java/dandi/dandi/member/application/service/MemberQueryServiceAdapterTest.java
+++ b/src/test/java/dandi/dandi/member/application/service/MemberQueryServiceAdapterTest.java
@@ -1,0 +1,75 @@
+package dandi.dandi.member.application.service;
+
+import static dandi.dandi.member.MemberTestFixture.INITIAL_PROFILE_IMAGE_URL;
+import static dandi.dandi.member.MemberTestFixture.NICKNAME;
+import static dandi.dandi.member.MemberTestFixture.OAUTH_ID;
+import static dandi.dandi.utils.TestImageUtils.IMAGE_ACCESS_URL;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.when;
+
+import dandi.dandi.auth.exception.UnauthorizedException;
+import dandi.dandi.member.application.port.in.MemberInfoResponse;
+import dandi.dandi.member.application.port.in.NicknameDuplicationCheckResponse;
+import dandi.dandi.member.application.port.out.MemberPersistencePort;
+import dandi.dandi.member.domain.Member;
+import dandi.dandi.post.application.port.out.MemberPostPersistencePort;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class MemberQueryServiceAdapterTest {
+
+    private final MemberPersistencePort memberPersistencePort = Mockito.mock(MemberPersistencePort.class);
+    private final MemberPostPersistencePort memberPostPersistencePort = Mockito.mock(MemberPostPersistencePort.class);
+    private final MemberQueryServiceAdapter memberQueryServiceAdapter =
+            new MemberQueryServiceAdapter(memberPersistencePort, memberPostPersistencePort, IMAGE_ACCESS_URL);
+
+    @DisplayName("기본 프로필 이미지의 회원 정보를 반환할 수 있다.")
+    @Test
+    void findMemberInfo() {
+        Long memberId = 1L;
+        when(memberPersistencePort.findById(memberId))
+                .thenReturn(Optional.of(Member.initial(OAUTH_ID, NICKNAME, INITIAL_PROFILE_IMAGE_URL)));
+        when(memberPostPersistencePort.countPostByMemberId(memberId))
+                .thenReturn(5);
+
+        MemberInfoResponse memberInfoResponse = memberQueryServiceAdapter.findMemberInfo(memberId);
+
+        assertAll(
+                () -> assertThat(memberInfoResponse.getNickname()).isEqualTo(NICKNAME),
+                () -> assertThat(memberInfoResponse.getPostCount()).isEqualTo(5),
+                () -> assertThat(memberInfoResponse.getLatitude()).isEqualTo(0.0),
+                () -> assertThat(memberInfoResponse.getLongitude()).isEqualTo(0.0),
+                () -> assertThat(memberInfoResponse.getProfileImageUrl())
+                        .startsWith(IMAGE_ACCESS_URL + INITIAL_PROFILE_IMAGE_URL)
+        );
+    }
+
+    @DisplayName("존재하지 않는 회원의 정보를 반환하려하면 예외를 발생시킨다.")
+    @Test
+    void findMemberInfo_NonExistentMember() {
+        Long nonExistentMemberId = 1L;
+        when(memberPersistencePort.findById(nonExistentMemberId))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> memberQueryServiceAdapter.findMemberInfo(nonExistentMemberId))
+                .isInstanceOf(UnauthorizedException.class)
+                .hasMessage(UnauthorizedException.notExistentMember().getMessage());
+    }
+
+    @DisplayName("중복된 닉네임이 있는지 반환한다.")
+    @Test
+    void checkDuplication() {
+        Long memberId = 1L;
+        String nickname = "nickname";
+        when(memberPersistencePort.existsMemberByNicknameExceptMine(memberId, nickname))
+                .thenReturn(true);
+
+        NicknameDuplicationCheckResponse actual = memberQueryServiceAdapter.checkDuplication(memberId, nickname);
+
+        assertThat(actual.isDuplicated()).isTrue();
+    }
+}

--- a/src/test/java/dandi/dandi/member/application/service/MemberUseCaseServiceAdapterTest.java
+++ b/src/test/java/dandi/dandi/member/application/service/MemberUseCaseServiceAdapterTest.java
@@ -1,33 +1,22 @@
-package dandi.dandi.member.application;
+package dandi.dandi.member.application.service;
 
 import static dandi.dandi.member.MemberTestFixture.DISTRICT;
 import static dandi.dandi.member.MemberTestFixture.DISTRICT_VALUE;
-import static dandi.dandi.member.MemberTestFixture.INITIAL_PROFILE_IMAGE_URL;
 import static dandi.dandi.member.MemberTestFixture.MEMBER;
 import static dandi.dandi.member.MemberTestFixture.MEMBER_ID;
-import static dandi.dandi.member.MemberTestFixture.NICKNAME;
-import static dandi.dandi.member.MemberTestFixture.OAUTH_ID;
-import static dandi.dandi.utils.TestImageUtils.IMAGE_ACCESS_URL;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import dandi.dandi.auth.exception.UnauthorizedException;
 import dandi.dandi.common.exception.NotFoundException;
 import dandi.dandi.member.application.port.in.LocationUpdateCommand;
 import dandi.dandi.member.application.port.in.MemberBlockCommand;
-import dandi.dandi.member.application.port.in.MemberInfoResponse;
 import dandi.dandi.member.application.port.in.NicknameUpdateCommand;
 import dandi.dandi.member.application.port.out.MemberBlockPersistencePort;
 import dandi.dandi.member.application.port.out.MemberPersistencePort;
-import dandi.dandi.member.application.service.MemberService;
 import dandi.dandi.member.domain.DistrictParser;
 import dandi.dandi.member.domain.Location;
-import dandi.dandi.member.domain.Member;
-import dandi.dandi.post.application.port.out.MemberPostPersistencePort;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,48 +26,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
 
 @ExtendWith(MockitoExtension.class)
-class MemberServiceTest {
+class MemberUseCaseServiceAdapterTest {
 
     private final MemberPersistencePort memberPersistencePort = Mockito.mock(MemberPersistencePort.class);
     private final MemberBlockPersistencePort memberBlockPersistencePort =
             Mockito.mock(MemberBlockPersistencePort.class);
-    private final MemberPostPersistencePort memberPostPersistencePort = Mockito.mock(MemberPostPersistencePort.class);
     private final DistrictParser districtParser = new DistrictParser();
-    private final MemberService memberService = new MemberService(memberPersistencePort, memberBlockPersistencePort,
-            memberPostPersistencePort, districtParser, IMAGE_ACCESS_URL);
-
-    @DisplayName("기본 프로필 이미지의 회원 정보를 반환할 수 있다.")
-    @Test
-    void findMemberInfo() {
-        Long memberId = 1L;
-        when(memberPersistencePort.findById(memberId))
-                .thenReturn(Optional.of(Member.initial(OAUTH_ID, NICKNAME, INITIAL_PROFILE_IMAGE_URL)));
-        when(memberPostPersistencePort.countPostByMemberId(memberId))
-                .thenReturn(5);
-
-        MemberInfoResponse memberInfoResponse = memberService.findMemberInfo(memberId);
-
-        assertAll(
-                () -> assertThat(memberInfoResponse.getNickname()).isEqualTo(NICKNAME),
-                () -> assertThat(memberInfoResponse.getPostCount()).isEqualTo(5),
-                () -> assertThat(memberInfoResponse.getLatitude()).isEqualTo(0.0),
-                () -> assertThat(memberInfoResponse.getLongitude()).isEqualTo(0.0),
-                () -> assertThat(memberInfoResponse.getProfileImageUrl())
-                        .startsWith(IMAGE_ACCESS_URL + INITIAL_PROFILE_IMAGE_URL)
-        );
-    }
-
-    @DisplayName("존재하지 않는 회원의 정보를 반환하려하면 예외를 발생시킨다.")
-    @Test
-    void findMemberInfo_NonExistentMember() {
-        Long nonExistentMemberId = 1L;
-        when(memberPersistencePort.findById(nonExistentMemberId))
-                .thenReturn(Optional.empty());
-
-        assertThatThrownBy(() -> memberService.findMemberInfo(nonExistentMemberId))
-                .isInstanceOf(UnauthorizedException.class)
-                .hasMessage(UnauthorizedException.notExistentMember().getMessage());
-    }
+    private final MemberUseCaseServiceAdapter memberService =
+            new MemberUseCaseServiceAdapter(memberPersistencePort, memberBlockPersistencePort, districtParser);
 
     @DisplayName("회원의 닉네임을 변경할 수 있다.")
     @Test

--- a/src/test/java/dandi/dandi/member/domain/MemberRepositoryTest.java
+++ b/src/test/java/dandi/dandi/member/domain/MemberRepositoryTest.java
@@ -4,8 +4,8 @@ import static dandi.dandi.member.MemberTestFixture.MEMBER_JPA_ENTITY;
 import static dandi.dandi.member.MemberTestFixture.OAUTH_ID;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-import dandi.dandi.member.adapter.out.persistence.MemberJpaEntity;
-import dandi.dandi.member.adapter.out.persistence.MemberRepository;
+import dandi.dandi.member.adapter.out.persistence.jpa.MemberEntity;
+import dandi.dandi.member.adapter.out.persistence.jpa.MemberRepository;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,7 +27,7 @@ class MemberRepositoryTest {
     void findByOAuthId() {
         memberRepository.save(MEMBER_JPA_ENTITY);
 
-        Optional<MemberJpaEntity> member = memberRepository.findByOAuthId(OAUTH_ID);
+        Optional<MemberEntity> member = memberRepository.findByOAuthId(OAUTH_ID);
 
         assertThat(member).isPresent();
     }

--- a/src/test/java/dandi/dandi/member/domain/nicknamegenerator/RandomNicknameGeneratorTest.java
+++ b/src/test/java/dandi/dandi/member/domain/nicknamegenerator/RandomNicknameGeneratorTest.java
@@ -14,6 +14,6 @@ class RandomNicknameGeneratorTest {
     void generate_Length_LowerThan23() {
         String randomNickname = randomNicknameGenerator.generate();
 
-        assertThat(randomNickname.length()).isLessThan(23);
+        assertThat(randomNickname.length()).isLessThanOrEqualTo(23);
     }
 }


### PR DESCRIPTION
resolve #333 
member package의 application port와 port와 adapter, web의 controller의 로직은 command와 query로 분리된 객체로 변경