### PR TITLE
refactor: core에서 Spring Event 의존성 분리

### DIFF
--- a/src/main/java/dandi/dandi/comment/application/service/CommentCommandServiceAdapter.java
+++ b/src/main/java/dandi/dandi/comment/application/service/CommentCommandServiceAdapter.java
@@ -7,9 +7,9 @@ import dandi.dandi.comment.domain.Comment;
 import dandi.dandi.comment.domain.CommentCreatedEvent;
 import dandi.dandi.common.exception.ForbiddenException;
 import dandi.dandi.common.exception.NotFoundException;
+import dandi.dandi.event.application.port.out.EventPort;
 import dandi.dandi.post.application.port.out.PostPersistencePort;
 import dandi.dandi.post.domain.Post;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,14 +18,14 @@ public class CommentCommandServiceAdapter implements CommentUseCaseServicePort {
 
     private final CommentPersistencePort commentPersistencePort;
     private final PostPersistencePort postPersistencePort;
-    private final ApplicationEventPublisher applicationEventPublisher;
+    private final EventPort eventPort;
 
     public CommentCommandServiceAdapter(CommentPersistencePort commentPersistencePort,
                                         PostPersistencePort postPersistencePort,
-                                        ApplicationEventPublisher applicationEventPublisher) {
+                                        EventPort eventPort) {
         this.commentPersistencePort = commentPersistencePort;
         this.postPersistencePort = postPersistencePort;
-        this.applicationEventPublisher = applicationEventPublisher;
+        this.eventPort = eventPort;
     }
 
     @Override
@@ -40,7 +40,7 @@ public class CommentCommandServiceAdapter implements CommentUseCaseServicePort {
 
     private void publishPostNotificationIfNotifiable(Long memberId, Post post, Long commentId) {
         if (!post.isWrittenBy(memberId)) {
-            applicationEventPublisher.publishEvent(
+            eventPort.publishEvent(
                     new CommentCreatedEvent(post.getWriterId(), post.getId(), commentId));
         }
     }

--- a/src/main/java/dandi/dandi/event/adapter/out/SpringEventAdapter.java
+++ b/src/main/java/dandi/dandi/event/adapter/out/SpringEventAdapter.java
@@ -1,0 +1,20 @@
+package dandi.dandi.event.adapter.out;
+
+import dandi.dandi.event.application.port.out.EventPort;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SpringEventAdapter implements EventPort {
+
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    public SpringEventAdapter(ApplicationEventPublisher applicationEventPublisher) {
+        this.applicationEventPublisher = applicationEventPublisher;
+    }
+
+    @Override
+    public void publishEvent(Object event) {
+        applicationEventPublisher.publishEvent(event);
+    }
+}

--- a/src/main/java/dandi/dandi/event/application/port/out/EventPort.java
+++ b/src/main/java/dandi/dandi/event/application/port/out/EventPort.java
@@ -1,0 +1,6 @@
+package dandi.dandi.event.application.port.out;
+
+public interface EventPort {
+
+    void publishEvent(Object event);
+}

--- a/src/main/java/dandi/dandi/member/application/service/MemberSignupManager.java
+++ b/src/main/java/dandi/dandi/member/application/service/MemberSignupManager.java
@@ -1,11 +1,11 @@
 package dandi.dandi.member.application.service;
 
+import dandi.dandi.event.application.port.out.EventPort;
 import dandi.dandi.member.application.port.out.MemberPersistencePort;
 import dandi.dandi.member.domain.Member;
 import dandi.dandi.member.domain.NewMemberCreatedEvent;
 import dandi.dandi.member.domain.nicknamegenerator.NicknameGenerator;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -14,15 +14,15 @@ public class MemberSignupManager {
     private final MemberPersistencePort memberPersistencePort;
     private final NicknameGenerator nicknameGenerator;
     private final String initialProfileImageUrl;
-    private final ApplicationEventPublisher applicationEventPublisher;
+    private final EventPort eventPort;
 
     public MemberSignupManager(MemberPersistencePort memberPersistencePort, NicknameGenerator nicknameGenerator,
                                @Value("${image.member-initial-profile-image-url}") String initialProfileImageUrl,
-                               ApplicationEventPublisher applicationEventPublisher) {
+                               EventPort eventPort) {
         this.memberPersistencePort = memberPersistencePort;
         this.nicknameGenerator = nicknameGenerator;
         this.initialProfileImageUrl = initialProfileImageUrl;
-        this.applicationEventPublisher = applicationEventPublisher;
+        this.eventPort = eventPort;
     }
 
     public Long signup(String oAuthMemberId, String pushNotificationToken) {
@@ -32,7 +32,7 @@ public class MemberSignupManager {
         }
         Member newMember = memberPersistencePort.save(
                 Member.initial(oAuthMemberId, randomNickname, initialProfileImageUrl));
-        applicationEventPublisher.publishEvent(new NewMemberCreatedEvent(newMember.getId(), pushNotificationToken));
+        eventPort.publishEvent(new NewMemberCreatedEvent(newMember.getId(), pushNotificationToken));
         return newMember.getId();
     }
 }

--- a/src/main/java/dandi/dandi/postlike/application/service/PostLikeCommandServiceAdapter.java
+++ b/src/main/java/dandi/dandi/postlike/application/service/PostLikeCommandServiceAdapter.java
@@ -1,13 +1,13 @@
 package dandi.dandi.postlike.application.service;
 
 import dandi.dandi.common.exception.NotFoundException;
+import dandi.dandi.event.application.port.out.EventPort;
 import dandi.dandi.post.application.port.out.PostPersistencePort;
 import dandi.dandi.post.domain.Post;
 import dandi.dandi.postlike.application.port.in.PostLikeCommandServicePort;
 import dandi.dandi.postlike.application.port.out.PostLikePersistencePort;
 import dandi.dandi.postlike.domain.PostLike;
 import dandi.dandi.postlike.domain.PostLikedEvent;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,14 +17,13 @@ public class PostLikeCommandServiceAdapter implements PostLikeCommandServicePort
 
     private final PostPersistencePort postPersistencePort;
     private final PostLikePersistencePort postLikePersistencePort;
-    private final ApplicationEventPublisher applicationEventPublisher;
+    private final EventPort eventPort;
 
     public PostLikeCommandServiceAdapter(PostPersistencePort postPersistencePort,
-                                         PostLikePersistencePort postLikePersistencePort,
-                                         ApplicationEventPublisher applicationEventPublisher) {
+                                         PostLikePersistencePort postLikePersistencePort, EventPort eventPort) {
         this.postPersistencePort = postPersistencePort;
         this.postLikePersistencePort = postLikePersistencePort;
-        this.applicationEventPublisher = applicationEventPublisher;
+        this.eventPort = eventPort;
     }
 
     @Override
@@ -46,7 +45,7 @@ public class PostLikeCommandServiceAdapter implements PostLikeCommandServicePort
 
     private void publishPostLikeEventIfNotifiable(Long memberId, Post post) {
         if (!post.isWrittenBy(memberId)) {
-            applicationEventPublisher.publishEvent(new PostLikedEvent(post.getWriterId(), post.getId()));
+            eventPort.publishEvent(new PostLikedEvent(post.getWriterId(), post.getId()));
         }
     }
 }

--- a/src/test/java/dandi/dandi/member/domain/MemberSignupManagerTest.java
+++ b/src/test/java/dandi/dandi/member/domain/MemberSignupManagerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import dandi.dandi.event.application.port.out.EventPort;
 import dandi.dandi.member.application.port.out.MemberPersistencePort;
 import dandi.dandi.member.application.service.MemberSignupManager;
 import dandi.dandi.member.domain.nicknamegenerator.NicknameGenerator;
@@ -17,7 +18,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.context.ApplicationEventPublisher;
 
 @ExtendWith(MockitoExtension.class)
 class MemberSignupManagerTest {
@@ -29,7 +29,7 @@ class MemberSignupManagerTest {
     private MemberPersistencePort memberPersistencePort;
 
     @Mock
-    private ApplicationEventPublisher applicationEventPublisher;
+    private EventPort eventPort;
 
     @InjectMocks
     private MemberSignupManager memberSignupManager;
@@ -48,7 +48,7 @@ class MemberSignupManagerTest {
         Long newMemberId = memberSignupManager.signup(OAUTH_ID, pushNotitificationToken);
 
         assertThat(newMemberId).isEqualTo(MEMBER.getId());
-        verify(applicationEventPublisher).publishEvent(
+        verify(eventPort).publishEvent(
                 new NewMemberCreatedEvent(MEMBER.getId(), pushNotitificationToken));
     }
 }

--- a/src/test/java/dandi/dandi/postlike/application/service/PostLikeCommandServiceAdapterTest.java
+++ b/src/test/java/dandi/dandi/postlike/application/service/PostLikeCommandServiceAdapterTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import dandi.dandi.common.exception.NotFoundException;
+import dandi.dandi.event.application.port.out.EventPort;
 import dandi.dandi.post.application.port.out.PostPersistencePort;
 import dandi.dandi.postlike.application.port.out.PostLikePersistencePort;
 import dandi.dandi.postlike.domain.PostLike;
@@ -22,7 +23,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.context.ApplicationEventPublisher;
 
 @ExtendWith(MockitoExtension.class)
 class PostLikeCommandServiceAdapterTest {
@@ -34,7 +34,7 @@ class PostLikeCommandServiceAdapterTest {
     private PostLikePersistencePort postLikePersistencePort;
 
     @Mock
-    private ApplicationEventPublisher applicationEventPublisher;
+    private EventPort eventPort;
 
     @InjectMocks
     private PostLikeCommandServiceAdapter postLikeCommandServiceAdapter;
@@ -51,7 +51,7 @@ class PostLikeCommandServiceAdapterTest {
 
         assertAll(
                 () -> verify(postLikePersistencePort).save(any(PostLike.class)),
-                () -> verify(applicationEventPublisher, never()).publishEvent(any(PostLikedEvent.class))
+                () -> verify(eventPort, never()).publishEvent(any(PostLikedEvent.class))
         );
     }
 
@@ -68,7 +68,7 @@ class PostLikeCommandServiceAdapterTest {
 
         assertAll(
                 () -> verify(postLikePersistencePort).save(any(PostLike.class)),
-                () -> verify(applicationEventPublisher).publishEvent(any(PostLikedEvent.class))
+                () -> verify(eventPort).publishEvent(any(PostLikedEvent.class))
         );
     }
 


### PR DESCRIPTION
resolve #353 
Event 발행 방법 port-adapter 방식으로 변경.
Adapter에서 Spring Event 사용하도록 변경